### PR TITLE
'template' option name is changed to 'builder'

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ grunt.initConfig({
 
 ### Options
 
-#### options.template
+#### options.builder
 Type: `String`
 Default value: `null`
 


### PR DESCRIPTION
'template' does not work and custom 'builder' worked for me.